### PR TITLE
MonoDroid.Dialog not working with latest Mono for Android framework

### DIFF
--- a/MonoDroid.Dialog/DialogHelper.cs
+++ b/MonoDroid.Dialog/DialogHelper.cs
@@ -22,19 +22,19 @@ namespace MonoDroid.Dialog
             this.Root.Context = context;
 
             dialogView.Adapter = this.DialogAdapter = new DialogAdapter(context, this.Root);
-            dialogView.ItemClick += new EventHandler<ItemEventArgs>(ListView_ItemClick);
+            dialogView.ItemClick += new EventHandler<AdapterView.ItemClickEventArgs>(ListView_ItemClick);
             //dialogView.ItemLongClick += new EventHandler<ItemEventArgs>(ListView_ItemLongClick);
             dialogView.Tag = root;
         }
 
-        void ListView_ItemLongClick(object sender, ItemEventArgs e)
+		void ListView_ItemLongClick(object sender, AdapterView.ItemClickEventArgs e)
         {
             var elem = this.DialogAdapter.ElementAtIndex(e.Position);
             if (elem != null && elem.LongClick != null)
                 elem.LongClick(sender, e);
         }
 
-        void ListView_ItemClick(object sender, ItemEventArgs e)
+		void ListView_ItemClick(object sender, AdapterView.ItemClickEventArgs e)
         {
             var elem = this.DialogAdapter.ElementAtIndex(e.Position);
             if (elem != null && elem.Click != null)

--- a/MonoDroid.Dialog/EntryElement.cs
+++ b/MonoDroid.Dialog/EntryElement.cs
@@ -71,11 +71,11 @@ namespace MonoDroid.Dialog
                 _entry.Hint = this.Hint;
 
                 if (this.Password)
-                    _entry.InputType = (int)(InputTypes.ClassText | InputTypes.TextVariationPassword);
+                    _entry.InputType = (InputTypes.ClassText | InputTypes.TextVariationPassword);
                 else if (this.Numeric)
-                    _entry.InputType = (int)(InputTypes.ClassNumber | InputTypes.NumberFlagDecimal | InputTypes.NumberFlagSigned);
+                    _entry.InputType = (InputTypes.ClassNumber | InputTypes.NumberFlagDecimal | InputTypes.NumberFlagSigned);
                 else
-                    _entry.InputType = (int)InputTypes.ClassText;
+                    _entry.InputType = InputTypes.ClassText;
 
                 // continuation of crazy ass hack, stash away the listener value so we can look it up later
                 _entry.Tag = this;

--- a/MonoDroid.Dialog/RootElement.cs
+++ b/MonoDroid.Dialog/RootElement.cs
@@ -5,6 +5,7 @@ using Android.App;
 using Android.Content;
 using Android.Views;
 using Android.Widget;
+using MonoDroid.Dialog;
 
 namespace MonoDroid.Dialog
 {
@@ -377,17 +378,17 @@ namespace MonoDroid.Dialog
             dialog.Create().Show();
         }
 
-        void IDialogInterfaceOnClickListener.OnClick(IDialogInterface dialog, DialogInterfaceButton which)
-        {
-            if ((int)which >= 0)
-            {
-                this.RadioSelected = (int)which;
-                string radioValue = GetSelectedValue();
-                _value.Text = radioValue;
-            }
-
-            dialog.Dismiss();
-        }
+		void IDialogInterfaceOnClickListener.OnClick(IDialogInterface dialog, int which)
+		{
+			if (which >= 0)
+			{
+				this.RadioSelected = (int)which;
+				string radioValue = GetSelectedValue();
+				_value.Text = radioValue;
+			}
+			
+			dialog.Dismiss();
+		}
 
         /// <summary>
         /// Enumerator that returns all the sections in the RootElement.


### PR DESCRIPTION
...ake MonoDroid.Dialog compilable again.

I made the project run again, but the button isn't visible in the runner anymore (don't know why).
My changed were taken from the fixes that the Monocross project had made; they already indicated that MonoDroid.Dialog wasn't compatible with the latest Mono for Android frameworks..

Hope you'll have good use for this commit and even can make the button appear again ;)

grtz
